### PR TITLE
Fix randomUUID fallback

### DIFF
--- a/components/NuovoUtente.tsx
+++ b/components/NuovoUtente.tsx
@@ -22,7 +22,10 @@ export default function NuovoUtente() {
     setCaricamento(true);
     // Simulazione inserimento in Supabase: genera ID fittizio
     await new Promise((res) => setTimeout(res, 1000));
-    const fakeId = crypto.randomUUID();
+    const fakeId =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2);
     setIdUtente(fakeId);
     setCaricamento(false);
   };


### PR DESCRIPTION
## Summary
- make NuovoUtente component use a fallback when `crypto.randomUUID` is unavailable

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687858668de08324aac22ffabcf8fc22