### PR TITLE
Add Jest testing with sample test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Rinforzatori
+
+This project uses Next.js and React.
+
+## Running Tests
+
+Install dependencies and run the test suite with:
+
+```bash
+npm install
+npm test
+```

--- a/__tests__/rinforzatori.test.tsx
+++ b/__tests__/rinforzatori.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Rinforzatori from '../components/Rinforzatori';
+
+describe('Rinforzatori component', () => {
+  it('adds a new reinforcement to the list', async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce({ json: async () => [] })
+      .mockResolvedValueOnce({ json: async () => [{ id: '1', nome: 'Biscotto', emoji: '🌭' }] });
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    render(<Rinforzatori />);
+
+    fireEvent.change(screen.getByPlaceholderText('Incolla qui il token'), { target: { value: 'token' } });
+    fireEvent.change(screen.getByPlaceholderText('Es. Wurstel'), { target: { value: 'Biscotto' } });
+    fireEvent.click(screen.getByRole('button', { name: '➕' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('🌭 Biscotto')).toBeInTheDocument();
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        jsx: 'react-jsx'
+      }
+    }
+  }
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.5",
@@ -15,6 +16,12 @@
   "devDependencies": {
     "typescript": "^5.4.2",
     "@types/react": "^18.2.44",
-    "@types/node": "^18.19.34"
+    "@types/node": "^18.19.34",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.4.3",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library setup
- write a Rinforzatori component test
- document how to run the tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68785a2ee79c8324866762438a2cd4a1