### PR TITLE
Fix user registration via server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This project uses Next.js and React.
 
+## Environment variables
+
+Create a `.env.local` file with your Supabase credentials:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=<project url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key>
+SUPABASE_SERVICE_ROLE_KEY=<service role key>
+```
+
+The `SUPABASE_SERVICE_ROLE_KEY` is used only on the server to bypass row-level
+security when creating a new user.
+
 ## Running Tests
 
 Install dependencies and run the test suite with:

--- a/pages/api/utenti.ts
+++ b/pages/api/utenti.ts
@@ -1,0 +1,29 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+const supabase = createClient(supabaseUrl, serviceKey);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { nome, email, nome_cane, razza, eta, sesso, peso } = req.body;
+
+  const { data, error } = await supabase
+    .from('utenti')
+    .insert([{ nome, email, nome_cane, razza, eta, sesso, peso }])
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    console.error('Insert error:', error);
+    return res.status(500).json({ error: error.message });
+  }
+
+  res.status(200).json(data);
+}

--- a/pages/nuovo-utente.tsx
+++ b/pages/nuovo-utente.tsx
@@ -22,19 +22,13 @@ export default function NuovoUtente() {
     setCaricamento(true);
 
     try {
-      const res = await fetch(
-        "https://mcrrafxlbcolkpfwlvzz.supabase.co/rest/v1/utenti",
-        {
-          method: "POST",
-          headers: {
-            apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!}`,
-            "Content-Type": "application/json",
-            Prefer: "return=representation",
-          },
-          body: JSON.stringify(form),
-        }
-      );
+      const res = await fetch("/api/utenti", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(form),
+      });
 
       const data = await res.json();
 
@@ -45,7 +39,7 @@ export default function NuovoUtente() {
         return;
       }
 
-      setIdUtente(data[0].id);
+      setIdUtente(data.id);
     } catch (err) {
       console.error("Errore nel salvataggio:", err);
       alert("Errore nel salvataggio utente");


### PR DESCRIPTION
## Summary
- create `/api/utenti` endpoint that inserts users with the service key
- call the new API from the registration page
- document required environment variables

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687860cb96808324a9d3ffc249277b55