### PR TITLE
Fix missing Supabase key handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copia questo file in .env.local e sostituisci con la tua chiave anon di Supabase
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This project uses Next.js and React.
 
+## Configurazione
+
+Per poter salvare i dati su Supabase è necessario fornire la chiave anon del
+proprio progetto. Copia il file `.env.example` in `.env.local` e imposta il
+valore di `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+
+```bash
+cp .env.example .env.local
+echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=la-tua-chiave" >> .env.local
+```
+
 ## Running Tests
 
 Install dependencies and run the test suite with:

--- a/__tests__/rinforzatori.test.tsx
+++ b/__tests__/rinforzatori.test.tsx
@@ -3,6 +3,9 @@ import Rinforzatori from '../components/Rinforzatori';
 
 describe('Rinforzatori component', () => {
   it('adds a new reinforcement to the list', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test';
+    // @ts-ignore
+    global.alert = jest.fn();
     const fetchMock = jest.fn()
       .mockResolvedValueOnce({ json: async () => [] })
       .mockResolvedValueOnce({ json: async () => [{ id: '1', nome: 'Biscotto', emoji: '🌭' }] });

--- a/components/Rinforzatori.tsx
+++ b/components/Rinforzatori.tsx
@@ -17,6 +17,13 @@ export default function Rinforzatori() {
     if (!token || !nome) return alert("Inserisci token e nome");
     setCaricamento(true);
 
+    if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+      console.error("NEXT_PUBLIC_SUPABASE_ANON_KEY non è definita");
+      alert("Configurare la chiave anon di Supabase in .env.local");
+      setCaricamento(false);
+      return;
+    }
+
     const res = await fetch("https://mcrrafxlbcolkpfwlvzz.supabase.co/rest/v1/rinforzatori", {
       method: "POST",
       headers: {
@@ -40,6 +47,12 @@ export default function Rinforzatori() {
 
   const caricaEsistenti = async () => {
     if (!token) return;
+
+    if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+      console.error("NEXT_PUBLIC_SUPABASE_ANON_KEY non è definita");
+      alert("Configurare la chiave anon di Supabase in .env.local");
+      return;
+    }
     const res = await fetch(`https://mcrrafxlbcolkpfwlvzz.supabase.co/rest/v1/rinforzatori?id_utente=eq.${token}`, {
       headers: {
         apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,

--- a/pages/nuovo-utente.tsx
+++ b/pages/nuovo-utente.tsx
@@ -21,6 +21,13 @@ export default function NuovoUtente() {
   const salvaUtente = async () => {
     setCaricamento(true);
 
+    if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+      console.error("NEXT_PUBLIC_SUPABASE_ANON_KEY non è definita");
+      alert("Configurare la chiave anon di Supabase in .env.local");
+      setCaricamento(false);
+      return;
+    }
+
     try {
       const res = await fetch(
         "https://mcrrafxlbcolkpfwlvzz.supabase.co/rest/v1/utenti",

--- a/pages/rinforzatori.tsx
+++ b/pages/rinforzatori.tsx
@@ -17,6 +17,13 @@ export default function Rinforzatori() {
     if (!token || !nome) return alert("Inserisci token e nome");
     setCaricamento(true);
 
+    if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+      console.error("NEXT_PUBLIC_SUPABASE_ANON_KEY non è definita");
+      alert("Configurare la chiave anon di Supabase in .env.local");
+      setCaricamento(false);
+      return;
+    }
+
     try {
       const res = await fetch("https://mcrrafxlbcolkpfwlvzz.supabase.co/rest/v1/rinforzatori", {
         method: "POST",
@@ -53,6 +60,12 @@ export default function Rinforzatori() {
 
   const caricaEsistenti = async () => {
     if (!token) return;
+
+    if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+      console.error("NEXT_PUBLIC_SUPABASE_ANON_KEY non è definita");
+      alert("Configurare la chiave anon di Supabase in .env.local");
+      return;
+    }
 
     try {
       const res = await fetch(`https://mcrrafxlbcolkpfwlvzz.supabase.co/rest/v1/rinforzatori?id_utente=eq.${token}`, {


### PR DESCRIPTION
## Summary
- add instructions to set the Supabase anon key
- check for `NEXT_PUBLIC_SUPABASE_ANON_KEY` before API calls
- include example env file
- update test with env var

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879070e826c8324b12ec2c95ea97499